### PR TITLE
Add missing Iterator bound

### DIFF
--- a/src/iter_ext.rs
+++ b/src/iter_ext.rs
@@ -12,8 +12,8 @@ use ord_var::*;
 //use std::iter::MinMaxResult;
 
 /////////////////////////////////////////////////////////////////////
-pub trait AlmostOrdIterExt<T>: Iterator
-	where <T as Iterator>::Item: AlmostOrd
+pub trait AlmostOrdIterExt<T: Iterator>: Iterator
+	where T::Item: AlmostOrd
 {
 	/// Consumes the entire iterator to return the maximum element.
 	/// Values outside the ordered subset as given by `.is_outside_order()` are ignored.


### PR DESCRIPTION
The fixes from rust-lang/rust#27641 uncovered the fact that you are missing an Iterator bound here; otherwise, `<T as Iterator>::Item` doesn't make sense, since `T: Iterator` may not hold. In fact, now that a `T: Iterator` bound is given, you can just write `T::Item` instead. 
